### PR TITLE
ci: add build timestamp for CI debugging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Log build start time for debugging
+echo "Build started at: $(date)"
+
 export CUDA_HOME=${CUDA_HOME:-/usr/bin/}
 echo "PATH=${PATH}"
 echo "CUDA_HOME=${CUDA_HOME}"


### PR DESCRIPTION
## Summary
Add build start timestamp to `build.sh` to help diagnose CI timing issues and track build duration on self-hosted runners.

The timestamp output will appear in CI logs alongside existing diagnostic information (PATH, CUDA_HOME, etc.), making it easier to correlate build times with runner availability.

## Changes
- Added `echo "Build started at: $(date)"` to the beginning of `build.sh`

## Testing
- Change is non-functional and only adds diagnostic output
- Existing CI workflow will show the timestamp in logs